### PR TITLE
Change deprecated faker.name.findName() to faker.name.fullName()

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -120,7 +120,7 @@ function transformStringBasedOnFormat(format?: string, key?: string) {
   ) {
     return `faker.internet.url()`;
   } else if (key?.toLowerCase().endsWith('name')) {
-    return `faker.name.findName()`;
+    return `faker.name.fullName()`;
   } else {
     return `faker.lorem.slug(1)`;
   }


### PR DESCRIPTION
Hi there, thanks for this great package!

I am running `@faker-js/faker@7.4.0` in my project, and I'm seeing a warning in my console for each time `findName` is called:

![image](https://user-images.githubusercontent.com/1173045/190493297-8f22da38-0759-4e46-9f3e-9a1c0dcc86f7.png)

So I followed their advice, and here's my console after this PR:

![image](https://user-images.githubusercontent.com/1173045/190493477-d78ecd70-0de9-4759-9c84-a734a98dcad0.png)

Thanks again.