### PR TITLE
Update deprecated faker.js methods: .name and .number

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -98,7 +98,7 @@ function transformJSONSchemaToFakerCode(jsonSchema?: OpenAPIV3.SchemaObject, key
       return transformStringBasedOnFormat(jsonSchema.format, key);
     case 'number':
     case 'integer':
-      return `faker.datatype.number({ min: ${jsonSchema.minimum}, max: ${jsonSchema.maximum} })`;
+      return `faker.datatype.int({ min: ${jsonSchema.minimum}, max: ${jsonSchema.maximum} })`;
     case 'boolean':
       return `faker.datatype.boolean()`;
     case 'object':

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -98,7 +98,7 @@ function transformJSONSchemaToFakerCode(jsonSchema?: OpenAPIV3.SchemaObject, key
       return transformStringBasedOnFormat(jsonSchema.format, key);
     case 'number':
     case 'integer':
-      return `faker.datatype.int({ min: ${jsonSchema.minimum}, max: ${jsonSchema.maximum} })`;
+      return `faker.number.int({ min: ${jsonSchema.minimum}, max: ${jsonSchema.maximum} })`;
     case 'boolean':
       return `faker.datatype.boolean()`;
     case 'object':
@@ -116,7 +116,7 @@ function transformJSONSchemaToFakerCode(jsonSchema?: OpenAPIV3.SchemaObject, key
           .join(',\n')}
     }`;
     case 'array':
-      return `[...(new Array(faker.datatype.number({ min: ${jsonSchema.minLength ?? 1}, max: ${
+      return `[...(new Array(faker.number.int({ min: ${jsonSchema.minLength ?? 1}, max: ${
         jsonSchema.maxLength ?? 'MAX_ARRAY_LENGTH'
       } }))).keys()].map(_ => (${transformJSONSchemaToFakerCode(jsonSchema.items as OpenAPIV3.SchemaObject)}))`;
     default:
@@ -146,7 +146,7 @@ function transformStringBasedOnFormat(format?: string, key?: string) {
   ) {
     return `faker.internet.url()`;
   } else if (key?.toLowerCase().endsWith('name')) {
-    return `faker.name.fullName()`;
+    return `faker.person.fullName()`;
   } else {
     return `faker.lorem.slug(1)`;
   }


### PR DESCRIPTION
Hi there, I had [PRed](https://github.com/zoubingwu/msw-auto-mock/pull/12) you previously about deprecated faker.js methods causing console spam, and evidently there are a couple of new ones in 8.0.

![image](https://github.com/zoubingwu/msw-auto-mock/assets/1173045/65ec7270-59db-4cb6-9ed1-4f5faf397d31)

![image](https://github.com/zoubingwu/msw-auto-mock/assets/1173045/31b422fc-0442-457a-9601-bd41aeb82428)

I also checked out the [7.0 and 8.0 release notes](https://next.fakerjs.dev/guide/upgrading.html) and didn't see any others present in the `transform.ts` file.