### PR TITLE
uuid for strings equal to id or ending with _id

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,6 +1,6 @@
-import { OpenAPIV3 } from 'openapi-types';
-import merge from 'lodash/merge';
 import camelCase from 'lodash/camelCase';
+import merge from 'lodash/merge';
+import { OpenAPIV3 } from 'openapi-types';
 
 export interface ResponseMap {
   code: string;
@@ -130,7 +130,7 @@ function transformJSONSchemaToFakerCode(jsonSchema?: OpenAPIV3.SchemaObject, key
 function transformStringBasedOnFormat(format?: string, key?: string) {
   if (['date-time', 'date', 'time'].includes(format ?? '') || key?.toLowerCase().endsWith('_at')) {
     return `faker.date.past()`;
-  } else if (format === 'uuid') {
+  } else if (format === 'uuid' || key?.toLowerCase() === 'id' || key?.toLowerCase().endsWith('_id')) {
     return `faker.datatype.uuid()`;
   } else if (['idn-email', 'email'].includes(format ?? '') || key?.toLowerCase().endsWith('email')) {
     return `faker.internet.email()`;

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -131,7 +131,7 @@ function transformStringBasedOnFormat(format?: string, key?: string) {
   if (['date-time', 'date', 'time'].includes(format ?? '') || key?.toLowerCase().endsWith('_at')) {
     return `faker.date.past()`;
   } else if (format === 'uuid' || key?.toLowerCase() === 'id' || key?.toLowerCase().endsWith('_id')) {
-    return `faker.datatype.uuid()`;
+    return `faker.string.uuid()`;
   } else if (['idn-email', 'email'].includes(format ?? '') || key?.toLowerCase().endsWith('email')) {
     return `faker.internet.email()`;
   } else if (['hostname', 'idn-hostname'].includes(format ?? '')) {
@@ -144,9 +144,8 @@ function transformStringBasedOnFormat(format?: string, key?: string) {
     ['uri', 'uri-reference', 'iri', 'iri-reference', 'uri-template'].includes(format ?? '') ||
     key?.toLowerCase().endsWith('url')
   ) {
-    if (['photo', 'image', 'picture'].some(image => key?.toLowerCase().includes(image)))
-    {
-      return `faker.image.image()`
+    if (['photo', 'image', 'picture'].some(image => key?.toLowerCase().includes(image))) {
+      return `faker.image.image()`;
     }
     return `faker.internet.url()`;
   } else if (key?.toLowerCase().endsWith('name')) {


### PR DESCRIPTION
I don't know how much on purpose was this choice, but this library generates UUID only for strings with a specified UUID format. Considering most of the times a string property named `id` or ending with `_id` is a UUID or at least some kind of unique identifier, I consider this PR useful.

I'm open to critics and other considerations regarding this.