### PR TITLE
feat: added static generation mocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ example/test*.js
 
 .idea/
 .vscode/
+.DS_Store
 
 *.log

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Run you app then you'll see a successful activation message from Mock Service Wo
 ## Options
 
 - `-o, --output`: specify output file path or output to stdout.
+- `--static`: By default it will generate dynamic mocks, use this flag if you want generate static mocks.
 - `-m, --max-array-length <number>`: specify max array length in response, default value is `20`, it'll cost some time if you want to generate a huge chunk of random data.
 - `-t, --includes <keywords>`: specify keywords to match if you want to generate mock data only for certain requests, multiple keywords can be seperated with comma.
 - `-e, --excludes <keywords>`: specify keywords to exclude, multiple keywords can be seperated with comma.

--- a/example/public/mockServiceWorker.js
+++ b/example/public/mockServiceWorker.js
@@ -155,8 +155,7 @@ async function handleRequest(event, requestId) {
           ok: clonedResponse.ok,
           status: clonedResponse.status,
           statusText: clonedResponse.statusText,
-          body:
-            clonedResponse.body === null ? null : await clonedResponse.text(),
+          body: clonedResponse.body === null ? null : await clonedResponse.text(),
           headers: Object.fromEntries(clonedResponse.headers.entries()),
           redirected: clonedResponse.redirected,
         },

--- a/example/src/App.jsx
+++ b/example/src/App.jsx
@@ -1,15 +1,6 @@
 import { useState } from 'react';
 
-const methods = [
-  'GET',
-  'POST',
-  'PUT',
-  'PATCH',
-  'DELETE',
-  'HEAD',
-  'OPTIONS',
-  'TRACE',
-];
+const methods = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS', 'TRACE'];
 
 function App() {
   const [method, setMethod] = useState(methods[0]);
@@ -30,11 +21,7 @@ function App() {
       </select>
       <br />
       <label>Endpoint: </label>
-      <input
-        type="text"
-        value={endpoint}
-        onChange={e => setEndpoint(e.target.value)}
-      />
+      <input type="text" value={endpoint} onChange={e => setEndpoint(e.target.value)} />
       <br />
       <button
         onClick={async () => {

--- a/example/src/index.css
+++ b/example/src/index.css
@@ -1,14 +1,12 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans',
+    'Droid Sans', 'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 code {
   font-size: 11px;
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,7 @@ const cli = cac();
 cli
   .command('<spec>', 'Generating msw mock definitions with random fake data.')
   .option('-o, --output <file>', `Output file path such as \`./mock.js\`, without it'll output to stdout.`)
+  .option('--static', 'By default it will generate dynamic mocks, use this flag if you want generate static mocks.')
   .option('-m, --max-array-length <number>', `Max array length, default to 20.`)
   .option('-t, --includes <keywords>', `Include the request path with given string, can be seperated with comma.`)
   .option('-e, --excludes <keywords>', `Exclude the request path with given string, can be seperated with comma.`)

--- a/src/template.ts
+++ b/src/template.ts
@@ -34,8 +34,8 @@ ${getImportsCode(options)}
 faker.seed(1);
 
 const baseURL = '${baseURL}';
-const MAX_ARRAY_LENGTH = ${options?.maxArrayLength ?? 20};
 
+${options?.static === true ? '' : `const MAX_ARRAY_LENGTH = ${options?.maxArrayLength ?? 20};`}
 let i = 0;
 const next = () => {
   if (i === Number.MAX_SAFE_INTEGER - 1) {
@@ -48,7 +48,7 @@ export const handlers = [
   ${transformToHandlerCode(operationCollection)}
 ];
 
-${transformToResObject(operationCollection)}
+${transformToResObject(operationCollection, options)}
 
 // This configures a Service Worker with the given request handlers.
 export const startWorker = () => {

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,6 +1,14 @@
 import { OpenAPIV3 } from 'openapi-types';
 import merge from 'lodash/merge';
 import camelCase from 'lodash/camelCase';
+import { faker } from '@faker-js/faker';
+import { CliOptions } from './types';
+
+type BasePropsType = {
+  jsonSchema?: OpenAPIV3.SchemaObject;
+  key?: string;
+  config?: CliOptions;
+};
 
 export interface ResponseMap {
   code: string;
@@ -23,7 +31,7 @@ export function getResIdentifierName(res: ResponseMap) {
   return camelCase(`get ${res.id}${res.code}Response`);
 }
 
-export function transformToResObject(operationCollection: OperationCollection): string {
+export function transformToResObject(operationCollection: OperationCollection, config?: CliOptions): string {
   return operationCollection
     .map(op =>
       op.response
@@ -32,9 +40,10 @@ export function transformToResObject(operationCollection: OperationCollection): 
           if (!name) {
             return '';
           }
-          return `export function ${getResIdentifierName(r)}() { return ${transformJSONSchemaToFakerCode(
-            r.responses?.['application/json']
-          )} };\n`;
+          return `export function ${getResIdentifierName(r)}() { return ${transformJSONSchemaToFakerCode({
+            jsonSchema: r.responses?.['application/json'],
+            config,
+          })} };\n`;
         })
         .join('\n')
     )
@@ -59,7 +68,9 @@ export function transformToHandlerCode(operationCollection: OperationCollection)
     .trimEnd();
 }
 
-function transformJSONSchemaToFakerCode(jsonSchema?: OpenAPIV3.SchemaObject, key?: string): string {
+type TransformJSONSchemaToFakerCodePropsType = BasePropsType & {};
+
+function transformJSONSchemaToFakerCode({ jsonSchema, key, config }: TransformJSONSchemaToFakerCodePropsType): string {
   if (!jsonSchema) {
     return 'null';
   }
@@ -69,56 +80,124 @@ function transformJSONSchemaToFakerCode(jsonSchema?: OpenAPIV3.SchemaObject, key
   }
 
   if (Array.isArray(jsonSchema.type)) {
+    if (config?.static === true) {
+      return `[${faker.helpers.arrayElement([
+        jsonSchema.type
+          .map(type => transformJSONSchemaToFakerCode({ jsonSchema: { ...jsonSchema, type }, config }))
+          .join(','),
+      ])}]`;
+    }
+
     return `faker.helpers.arrayElement([${jsonSchema.type
-      .map(type => transformJSONSchemaToFakerCode({ ...jsonSchema, type }))
+      .map(type => transformJSONSchemaToFakerCode({ jsonSchema: { ...jsonSchema, type }, config }))
       .join(',')}])`;
   }
 
   if (jsonSchema.enum) {
+    if (config?.static === true) {
+      return `"${faker.helpers.arrayElement(jsonSchema.enum)}"`;
+    }
+
     return `faker.helpers.arrayElement(${JSON.stringify(jsonSchema.enum)})`;
   }
 
   if (jsonSchema.allOf) {
     const schemas = jsonSchema.allOf as OpenAPIV3.SchemaObject[];
-    return transformJSONSchemaToFakerCode(merge({}, ...schemas));
+
+    return transformJSONSchemaToFakerCode({ jsonSchema: merge({}, ...schemas), config });
   }
 
   if (jsonSchema.oneOf) {
     const schemas = jsonSchema.oneOf as OpenAPIV3.SchemaObject[];
-    return `faker.helpers.arrayElement([${schemas.map(i => transformJSONSchemaToFakerCode(i))}])`;
+
+    if (config?.static === true) {
+      return `${faker.helpers.arrayElement(
+        schemas.map(i => transformJSONSchemaToFakerCode({ jsonSchema: i, config }))
+      )}`;
+    }
+
+    return `faker.helpers.arrayElement([${schemas.map(i =>
+      transformJSONSchemaToFakerCode({ jsonSchema: i, config })
+    )}])`;
   }
 
   if (jsonSchema.anyOf) {
     const schemas = jsonSchema.anyOf as OpenAPIV3.SchemaObject[];
-    return `faker.helpers.arrayElement([${schemas.map(i => transformJSONSchemaToFakerCode(i))}])`;
+
+    if (config?.static === true) {
+      return `${faker.helpers.arrayElement(
+        schemas.map(i => transformJSONSchemaToFakerCode({ jsonSchema: i, config }))
+      )}`;
+    }
+
+    return `faker.helpers.arrayElement([${schemas.map(i =>
+      transformJSONSchemaToFakerCode({ jsonSchema: i, config })
+    )}])`;
   }
 
   switch (jsonSchema.type) {
     case 'string':
-      return transformStringBasedOnFormat(jsonSchema.format, key);
+      return transformStringBasedOnFormat({ format: jsonSchema.format, key, config });
     case 'number':
     case 'integer':
+      if (config?.static === true) {
+        return `${faker.number.int({ min: jsonSchema.minimum, max: jsonSchema.maximum })}`;
+      }
+
       return `faker.number.int({ min: ${jsonSchema.minimum}, max: ${jsonSchema.maximum} })`;
     case 'boolean':
+      if (config?.static === true) {
+        return `${faker.datatype.boolean()}`;
+      }
+
       return `faker.datatype.boolean()`;
     case 'object':
       if (!jsonSchema.properties && typeof jsonSchema.additionalProperties === 'object') {
-        return `[...new Array(5).keys()].map(_ => ({ [faker.lorem.word()]: ${transformJSONSchemaToFakerCode(
-          jsonSchema.additionalProperties as OpenAPIV3.SchemaObject
-        )} })).reduce((acc, next) => Object.assign(acc, next), {})`;
+        const _value = transformJSONSchemaToFakerCode({
+          jsonSchema: jsonSchema.additionalProperties as OpenAPIV3.SchemaObject,
+          config,
+        });
+
+        if (config?.static === true) {
+          return `{${[...new Array(5).keys()].map(_ => `${faker.lorem.word()}: ${_value}`)}}`;
+        }
+
+        return `[...new Array(5).keys()].map(_ => ({ [faker.lorem.word()]: ${transformJSONSchemaToFakerCode({
+          jsonSchema: jsonSchema.additionalProperties as OpenAPIV3.SchemaObject,
+        })} })).reduce((acc, next) => Object.assign(acc, next), {})`;
       }
 
       return `{
         ${Object.entries(jsonSchema.properties ?? {})
           .map(([k, v]) => {
-            return `${JSON.stringify(k)}: ${transformJSONSchemaToFakerCode(v as OpenAPIV3.SchemaObject, k)}`;
+            return `${JSON.stringify(k)}: ${transformJSONSchemaToFakerCode({
+              jsonSchema: v as OpenAPIV3.SchemaObject,
+              key: k,
+              config,
+            })}`;
           })
           .join(',\n')}
-    }`;
+      }`;
     case 'array':
+      if (config?.static === true) {
+        return `[${[
+          ...new Array(
+            faker.number.int({
+              min: jsonSchema.minLength ?? 1,
+              max: jsonSchema.maxLength ?? (config?.maxArrayLength || 20),
+            })
+          ).keys(),
+        ].map(_ =>
+          transformJSONSchemaToFakerCode({ jsonSchema: jsonSchema.items as OpenAPIV3.SchemaObject, config })
+        )}]`;
+      }
+
       return `[...(new Array(faker.number.int({ min: ${jsonSchema.minLength ?? 1}, max: ${
         jsonSchema.maxLength ?? 'MAX_ARRAY_LENGTH'
-      } }))).keys()].map(_ => (${transformJSONSchemaToFakerCode(jsonSchema.items as OpenAPIV3.SchemaObject)}))`;
+      } }))).keys()].map(_ => (${transformJSONSchemaToFakerCode({
+        jsonSchema: jsonSchema.items as OpenAPIV3.SchemaObject,
+        config,
+      })}))`;
     default:
       return 'null';
   }
@@ -127,31 +206,75 @@ function transformJSONSchemaToFakerCode(jsonSchema?: OpenAPIV3.SchemaObject, key
 /**
  * See https://json-schema.org/understanding-json-schema/reference/string.html#built-in-formats
  */
-function transformStringBasedOnFormat(format?: string, key?: string) {
+type TransformStringBasedOnFormatPropsType = Omit<BasePropsType, 'jsonSchema'> & {
+  format?: string;
+};
+
+function transformStringBasedOnFormat({ format, key, config }: TransformStringBasedOnFormatPropsType) {
   if (['date-time', 'date', 'time'].includes(format ?? '') || key?.toLowerCase().endsWith('_at')) {
+    if (config?.static === true) {
+      return `"${faker.date.past()}"`;
+    }
+
     return `faker.date.past()`;
   } else if (format === 'uuid') {
-    return `faker.datatype.uuid()`;
+    if (config?.static === true) {
+      return `"${faker.string.uuid()}"`;
+    }
+
+    return `faker.string.uuid()`;
   } else if (['idn-email', 'email'].includes(format ?? '') || key?.toLowerCase().endsWith('email')) {
+    if (config?.static === true) {
+      return `"${faker.internet.email()}"`;
+    }
+
     return `faker.internet.email()`;
   } else if (['hostname', 'idn-hostname'].includes(format ?? '')) {
+    if (config?.static === true) {
+      return `"${faker.internet.domainName()}"`;
+    }
+
     return `faker.internet.domainName()`;
   } else if (format === 'ipv4') {
+    if (config?.static === true) {
+      return `"${faker.internet.ip()}"`;
+    }
+
     return `faker.internet.ip()`;
   } else if (format === 'ipv6') {
+    if (config?.static === true) {
+      return `"${faker.internet.ipv6()}"`;
+    }
+
     return `faker.internet.ipv6()`;
   } else if (
     ['uri', 'uri-reference', 'iri', 'iri-reference', 'uri-template'].includes(format ?? '') ||
     key?.toLowerCase().endsWith('url')
   ) {
-    if (['photo', 'image', 'picture'].some(image => key?.toLowerCase().includes(image)))
-    {
-      return `faker.image.image()`
+    if (['photo', 'image', 'picture'].some(image => key?.toLowerCase().includes(image))) {
+      if (config?.static === true) {
+        return `"${faker.image.url()}"`;
+      }
+
+      return `faker.image.url()`;
     }
+
+    if (config?.static === true) {
+      return `"${faker.internet.url()}"`;
+    }
+
     return `faker.internet.url()`;
   } else if (key?.toLowerCase().endsWith('name')) {
+    if (config?.static === true) {
+      return `"${faker.person.fullName()}"`;
+    }
+
     return `faker.person.fullName()`;
   } else {
+    if (config?.static === true) {
+      return `"${faker.lorem.slug()}"`;
+    }
+
     return `faker.lorem.slug(1)`;
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,4 +7,5 @@ export interface CliOptions {
   node?: boolean;
   codes?: string;
   reactNative?: boolean;
+  static?: boolean;
 }


### PR DESCRIPTION
Hello everybody. So, here what I did. ; )

**What?**
Added an option for generating static mocks.

**Why?**
Firstly, we have an issue for this. ))

Some people can you this lib for generate mocks (prefer static) and use it for visual regression test, right now we can't give this option, but this PR fix this problem.

If you want to generate static mock - just add `--static` flag into command and run. 

**How?**
1. Added CLI option in the `cli.ts`.
2. Added condition into function, which is generating mocks. If we want static - we will return value, if we don't want - we return string with dynamic mock (I didn't change it, only added option for static).

P.S.
If you know how to make it more simple, comment below. ))