### PR TITLE
Fix issue with nested allOf missing object properties

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -79,8 +79,8 @@ function transformJSONSchemaToFakerCode(jsonSchema?: OpenAPIV3.SchemaObject, key
   }
 
   if (jsonSchema.allOf) {
-    const schemas = jsonSchema.allOf as OpenAPIV3.SchemaObject[];
-    return transformJSONSchemaToFakerCode(merge({}, ...schemas));
+    const { allOf, ...rest } = jsonSchema;
+    return transformJSONSchemaToFakerCode(merge({}, ...allOf, rest));
   }
 
   if (jsonSchema.oneOf) {
@@ -144,9 +144,8 @@ function transformStringBasedOnFormat(format?: string, key?: string) {
     ['uri', 'uri-reference', 'iri', 'iri-reference', 'uri-template'].includes(format ?? '') ||
     key?.toLowerCase().endsWith('url')
   ) {
-    if (['photo', 'image', 'picture'].some(image => key?.toLowerCase().includes(image)))
-    {
-      return `faker.image.image()`
+    if (['photo', 'image', 'picture'].some(image => key?.toLowerCase().includes(image))) {
+      return `faker.image.image()`;
     }
     return `faker.internet.url()`;
   } else if (key?.toLowerCase().endsWith('name')) {

--- a/test/fixture/test.yaml
+++ b/test/fixture/test.yaml
@@ -14,16 +14,17 @@ components:
               type: string
               minLength: 1
     BaseEntity:
-      type: object
-      properties:
-        id:
-          type: integer
-          minimum: 1
-        created_at:
-          type: string
-          format: date-time
-        creator:
-          $ref: '#/components/schemas/Creator' 
+      allOf:
+        - type: object
+          properties:
+            id:
+              type: integer
+              minimum: 1
+            created_at:
+              type: string
+              format: date-time
+            creator:
+              $ref: '#/components/schemas/Creator'
     TestEntity:
       description: TestEntity
       allOf:


### PR DESCRIPTION
Discovered an issue where nested allOf can cause some properties to be excluded. Spreading the other properties in with allOf resolves this.

Added a test to confirm this. Reverting transform.ts will cause the test to fail, since the expected property 'name' no longer exists on TestEntity in the generated code.