### PR TITLE
Update prettier version and improve error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "cac": "^6.7.12",
     "lodash": "^4.17.21",
     "oazapfts": "^4.5.2",
-    "prettier": "2.5.1",
+    "prettier": "3.1.0",
     "swagger2openapi": "^7.0.8"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^4.5.2
         version: 4.5.2(openapi-types@12.1.0)
       prettier:
-        specifier: 2.5.1
-        version: 2.5.1
+        specifier: 3.1.0
+        version: 3.1.0
       swagger2openapi:
         specifier: ^7.0.8
         version: 7.0.8
@@ -2273,9 +2273,9 @@ packages:
       source-map-js: 1.0.2
     dev: true
 
-  /prettier@2.5.1:
-    resolution: {integrity: sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==}
-    engines: {node: '>=10.13.0'}
+  /prettier@3.1.0:
+    resolution: {integrity: sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==}
+    engines: {node: '>=14'}
     hasBin: true
     dev: false
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -33,10 +33,18 @@ export async function prettify(filePath: string | null, content: string): Promis
     });
   }
 
-  return prettier.format(content, {
-    parser,
-    ...config,
-  });
+  try {
+    return prettier.format(content, {
+      parser,
+      ...config,
+
+      // disable plugins
+      plugins: [],
+    });
+  } catch (e) {
+    // ignore error
+    return content;
+  }
 }
 
 export const toExpressLikePath = (path: string) =>

--- a/test/__snapshots__/generate.spec.ts.snap
+++ b/test/__snapshots__/generate.spec.ts.snap
@@ -40,7 +40,7 @@ export function getGetTest200Response() {
       count: faker.number.int({ min: undefined, max: undefined }),
       rows: [
         ...new Array(
-          faker.number.int({ min: 1, max: MAX_ARRAY_LENGTH })
+          faker.number.int({ min: 1, max: MAX_ARRAY_LENGTH }),
         ).keys(),
       ].map((_) => ({
         id: faker.number.int({ min: 1, max: undefined }),


### PR DESCRIPTION
Fix #41 

The prettier version was updated from 2.5.1 to 3.1.0 across package.json and pnpm-lock.yaml. Additionally, in utils.ts, the prettier formatting function was wrapped in a try-catch block to prevent the application from crashing in case of an error, instead reverting back to the original content as a safe fallback. Also, small modifications were made in the test snap files.