### PR TITLE
fix: return promise from `start` call so that it can be awaited

### DIFF
--- a/src/template.ts
+++ b/src/template.ts
@@ -6,7 +6,7 @@ const getSetupCode = (options?: CliOptions) => {
     return [`const server = setupServer(...handlers);`, `server.listen();`].join('\n');
   }
 
-  return [`const worker = setupWorker(...handlers);`, `worker.start();`].join('\n');
+  return [`const worker = setupWorker(...handlers);`, `return worker.start();`].join('\n');
 };
 
 const getImportsCode = (options?: CliOptions) => {

--- a/test/__snapshots__/generate.spec.ts.snap
+++ b/test/__snapshots__/generate.spec.ts.snap
@@ -57,7 +57,7 @@ export function getGetTest200Response() {
 // This configures a Service Worker with the given request handlers.
 export const startWorker = () => {
   const worker = setupWorker(...handlers);
-  worker.start();
+  return worker.start();
 };
 "
 `;


### PR DESCRIPTION
This PR updates the setup code part of the template to return the promise from `worker.start()`. I had to update my template to return this so that I could make sure that msw was setup before rendering my app. I figure it should be the default 