### PR TITLE
Better date and address handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules/
-dist/
 example/src/mock.js
 example/test*.js
 

--- a/example/index.html
+++ b/example/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/example/src/index.css
+++ b/example/src/index.css
@@ -1,14 +1,12 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans',
+    'Droid Sans', 'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 code {
   font-size: 11px;
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
 }

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -119,7 +119,9 @@ function operationFilter(operation: OperationDefinition, options: CliOptions): b
 }
 
 function codeFilter(operation: OperationDefinition, options: CliOptions): OperationDefinition {
-  const codes = options?.codes?.split(',') ?? null;
+  const rawCodes = options?.codes;
+
+  const codes = rawCodes ? (rawCodes.indexOf(',') !== -1 ? rawCodes?.split(',') : [rawCodes]) : null;
 
   const responses = Object.entries(operation.responses)
     .filter(([code]) => {

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -174,8 +174,12 @@ function transformJSONSchemaToFakerCode(jsonSchema?: OpenAPIV3.SchemaObject, key
  */
 function transformStringBasedOnFormat(schema: OpenAPIV3.NonArraySchemaObject, key?: string) {
   const { format, minLength, maxLength } = schema;
-  if (['date-time', 'date', 'time'].includes(format ?? '') || key?.toLowerCase().endsWith('_at')) {
+  if (format === 'date-time' || key?.toLowerCase().endsWith('_at')) {
     return `faker.date.past()`;
+  } else if (format === 'time') {
+    return `new Date().toISOString().substring(11, 16)`;
+  } else if (format === 'date') {
+    return `faker.date.past().toISOString().substring(0,10)`;
   } else if (format === 'uuid') {
     return `faker.string.uuid()`;
   } else if (['idn-email', 'email'].includes(format ?? '') || key?.toLowerCase().endsWith('email')) {
@@ -196,6 +200,14 @@ function transformStringBasedOnFormat(schema: OpenAPIV3.NonArraySchemaObject, ke
     return `faker.internet.url()`;
   } else if (key?.toLowerCase().endsWith('name')) {
     return `faker.person.fullName()`;
+  } else if (key?.toLowerCase().indexOf('street') !== -1) {
+    return `faker.location.streetAddress()`;
+  } else if (key?.toLowerCase().indexOf('city') !== -1) {
+    return `faker.location.city()`;
+  } else if (key?.toLowerCase().indexOf('state') !== -1) {
+    return `faker.location.state()`;
+  } else if (key?.toLowerCase().indexOf('zip') !== -1) {
+    return `faker.location.zipCode()`;
   } else {
     if (minLength && maxLength) {
       return `faker.string.alpha({ length: { min: ${minLength}, max: ${maxLength} }})`;

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -180,7 +180,7 @@ function transformStringBasedOnFormat(schema: OpenAPIV3.NonArraySchemaObject, ke
     return `new Date().toISOString().substring(11, 16)`;
   } else if (format === 'date') {
     return `faker.date.past().toISOString().substring(0,10)`;
-  } else if (format === 'uuid' || key?.endsWith('Id') || key?.endsWith('ID')) {
+  } else if (format === 'uuid' || key?.toLowerCase() === 'id' || key?.endsWith('Id') || key?.endsWith('ID')) {
     return `faker.string.uuid()`;
   } else if (['idn-email', 'email'].includes(format ?? '') || key?.toLowerCase().includes('email')) {
     return `faker.internet.email()`;

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -180,9 +180,9 @@ function transformStringBasedOnFormat(schema: OpenAPIV3.NonArraySchemaObject, ke
     return `new Date().toISOString().substring(11, 16)`;
   } else if (format === 'date') {
     return `faker.date.past().toISOString().substring(0,10)`;
-  } else if (format === 'uuid') {
+  } else if (format === 'uuid' || key?.endsWith('Id') || key?.endsWith('ID')) {
     return `faker.string.uuid()`;
-  } else if (['idn-email', 'email'].includes(format ?? '') || key?.toLowerCase().endsWith('email')) {
+  } else if (['idn-email', 'email'].includes(format ?? '') || key?.toLowerCase().includes('email')) {
     return `faker.internet.email()`;
   } else if (['hostname', 'idn-hostname'].includes(format ?? '')) {
     return `faker.internet.domainName()`;

--- a/test/transform.spec.ts
+++ b/test/transform.spec.ts
@@ -5,7 +5,7 @@ import { generateOperationCollection } from '../src/generate';
 import { getV3Doc } from '../src/swagger';
 
 describe('transform:transformToGenerateResultFunctions', () => {
-  it('Generates a response function with epxected faker calls', async () => {
+  it('Generates a response function with expected faker calls', async () => {
     const apiDoc = await getV3Doc('./test/fixture/strings.yaml');
     const schema = generateOperationCollection(apiDoc, { output: '' });
 


### PR DESCRIPTION
Added better handling for string types when the format is 'date' or 'time'.
Added some additional checks to try and supply address fields with address data. 
Fixed a bug with the --codes cli option when the list of codes has only one code.