### PR TITLE
Allow for different resource content keys than application/json

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -54,7 +54,11 @@ export function transformToGenerateResultFunctions(
           const useFaker = options?.ai?.enable !== true;
 
           if (useFaker) {
-            const fakerResult = transformJSONSchemaToFakerCode(r.responses?.['application/json']);
+            if (!r.responses) {
+              return;
+            }
+            const jsonResponseKey = Object.keys(r.responses).filter(r => r.startsWith('application/json'))[0];
+            const fakerResult = transformJSONSchemaToFakerCode(r.responses?.[jsonResponseKey]);
             if (options?.static) {
               vm.runInContext(`result = ${fakerResult};`, context);
             }
@@ -67,7 +71,11 @@ export function transformToGenerateResultFunctions(
             ].join('\n');
           }
 
-          const operationString = JSON.stringify(r.responses?.['application/json'], null, 4);
+          if (!r.responses) {
+            return;
+          }
+          const jsonResponseKey = Object.keys(r.responses).filter(r => r.startsWith('application/json'))[0];
+          const operationString = JSON.stringify(r.responses?.[jsonResponseKey], null, 4);
           return [
             `export async function `,
             `${name}() { `,

--- a/test/fixture/test.yaml
+++ b/test/fixture/test.yaml
@@ -52,7 +52,7 @@ paths:
         '200':
           description: OK
           content:
-            application/json:
+            application/json; ; charset=utf-8;:
               schema:
                 allOf:
                   - $ref: '#/components/schemas/OkResponse'

--- a/test/generate.spec.ts
+++ b/test/generate.spec.ts
@@ -15,7 +15,7 @@ describe('generate:generateOperationCollection', () => {
   let schema: OpenAPIV3.SchemaObject;
   beforeAll(async () => {
     const collection = await generateCollectionFromSpec('./test/fixture/test.yaml');
-    schema = get(collection, [0, 'response', '0', 'responses', 'application/json', 'allOf', 1]);
+    schema = get(collection, [0, 'response', '0', 'responses', 'application/json; ; charset=utf-8;', 'allOf', 1]);
   });
 
   it('schema should be defined', () => {


### PR DESCRIPTION
The hardcoded response key resulted in `null` results for openAPI schemas with keys that had more than `application/json` in their content key, e.g.

```
paths:
  /status:
    get:
      responses:
        '200':
          description: OK
          headers: {}
          content:
            application/json; charset=utf-8;: <<<<< here, this is valid openapi
              schema:
                type: object
```

This PR updates it just to check for the start of the string allowing for variation.