### PR TITLE
Return faker.helpers.fromRegExp() for strings where string pattern is provided

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -4,6 +4,7 @@ import merge from 'lodash/merge';
 import camelCase from 'lodash/camelCase';
 import { faker } from '@faker-js/faker';
 import { ConfigOptions } from './types';
+import { isValidRegExp } from './utils';
 
 const MAX_STRING_LENGTH = 42;
 
@@ -98,7 +99,7 @@ export function transformToHandlerCode(operationCollection: OperationCollection)
     .trimEnd();
 }
 
-function transformJSONSchemaToFakerCode(jsonSchema?: OpenAPIV3.SchemaObject, key?: string): string {
+export function transformJSONSchemaToFakerCode(jsonSchema?: OpenAPIV3.SchemaObject, key?: string): string {
   if (!jsonSchema) {
     return 'null';
   }
@@ -136,6 +137,9 @@ function transformJSONSchemaToFakerCode(jsonSchema?: OpenAPIV3.SchemaObject, key
 
   switch (jsonSchema.type) {
     case 'string':
+      if (jsonSchema.pattern && isValidRegExp(jsonSchema.pattern)) {
+        return `faker.helpers.fromRegExp(${jsonSchema.pattern})`;
+      }
       return transformStringBasedOnFormat(jsonSchema, key);
     case 'number':
     case 'integer':

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -50,3 +50,13 @@ export async function prettify(filePath: string | null, content: string): Promis
 export const toExpressLikePath = (path: string) =>
   // use `.+?` for lazy match
   path.replace(/{(.+?)}/g, (_match, p1: string) => `:${camelCase(p1)}`);
+
+export const isValidRegExp = (regExpCandidate: string) => {
+  var isValid = true;
+  try {
+    new RegExp(regExpCandidate);
+  } catch (e) {
+    isValid = false;
+  }
+  return isValid;
+};

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -1,10 +1,27 @@
 import { describe, expect, it } from 'vitest';
 
-import { toExpressLikePath } from '../src/utils';
+import { isValidRegExp, toExpressLikePath } from '../src/utils';
 
 describe('utils:toExpressLikePath', () => {
   it('should transform to express like path', () => {
     expect(toExpressLikePath('/a/b/{c_d}')).toEqual('/a/b/:cD');
     expect(toExpressLikePath('/{a}/{b}/{c}')).toEqual('/:a/:b/:c');
+  });
+});
+
+describe('utils:isValidRegExp', () => {
+  it('test cases', () => {
+    [
+      ['/^S+@S+.S+$/', true],
+      ['employ(|er|ee|ment|ing|able)', true],
+      ['[a-f0-9]{32}', true],
+      ['[A-Fa-f0-9]{64}', true],
+      ['^[0-9]{2,6}.[0-9]{5}$', true],
+      ['<tag>[^<]*</tag>', true],
+      ['aaaaaaaaaaaaaaaa', true],
+      ['\\', false],
+    ].forEach(([i, o]) => {
+      expect(isValidRegExp(i as string)).toBe(o);
+    });
   });
 });


### PR DESCRIPTION
Extend transform string logic to return faker's fromRegExp() if a regexp pattern is provided, e.g.

```yaml
percent_change:
    type: string
    pattern: '/[0-9]{2}.[0-9]{2}/'
email_address:
    type: string
    pattern: '/[a-z]{5,15}@springfieldnuclear.org/'
``` 

Useful for cases where you want to return a random stringified number within certain parameters, e.g.
``` javascript
faker.helpers.fromRegExp(/[0-9]{2}.[0-9]{2}/)                  // "55.11"
faker.helpers.fromRegExp(/[a-z]{5,15}@springfieldnuclear.org/) // homerjsimpson@springfieldnuclear.org  
```

https://fakerjs.dev/api/helpers#fromregexp