### PR TITLE
fix: update next function to track API call counts

### DIFF
--- a/.changeset/three-islands-burn.md
+++ b/.changeset/three-islands-burn.md
@@ -1,0 +1,5 @@
+---
+'msw-auto-mock': minor
+---
+
+make next function to api scope instead of global

--- a/example/package.json
+++ b/example/package.json
@@ -5,7 +5,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "generate": "msw-auto-mock generate"
+    "generate": "msw-auto-mock ../test/fixture/test.yaml -o src/mock "
   },
   "dependencies": {
     "react": "^19.0.0",

--- a/src/template.ts
+++ b/src/template.ts
@@ -24,13 +24,17 @@ faker.seed(1);
 const baseURL = '${baseURL}';
 const MAX_ARRAY_LENGTH = ${options?.maxArrayLength ?? 20};
 
-let i = 0;
-const next = () => {
-  if (i === Number.MAX_SAFE_INTEGER - 1) {
-    i = 0;
+// Map to store counters for each API endpoint
+const apiCounters = new Map();
+
+const next = (apiKey) => {
+  let currentCount = apiCounters.get(apiKey) ?? 0;
+  if (currentCount === Number.MAX_SAFE_INTEGER - 1) {
+    currentCount = 0;
   }
-  return i++;
-}
+  apiCounters.set(apiKey, currentCount + 1);
+  return currentCount;
+};
 
 export const handlers = [
   ${transformToHandlerCode(operationCollection)}

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -100,7 +100,7 @@ export function transformToHandlerCode(operationCollection: OperationCollection)
             : `[${identifier ? `await ${identifier}()` : 'undefined'}, { status: ${parseInt(response?.code!)} }]`;
         })}];
 
-          return HttpResponse.json(...resultArray[next() % resultArray.length])
+          return HttpResponse.json(...resultArray[next(\`${op.verb} ${op.path}\`) % resultArray.length])
         }),\n`;
     })
     .join('  ')


### PR DESCRIPTION
close #79 

Replaced the simple counter in the next function with a Map to store counters for each API endpoint. This allows for individual tracking of API call counts based on the provided apiKey, preventing overflow and improving state management. Updated the transformToHandlerCode function to utilize the new next function with the appropriate API key.