### PR TITLE
feat: add `regex` argument

### DIFF
--- a/.changeset/four-crabs-love.md
+++ b/.changeset/four-crabs-love.md
@@ -1,0 +1,5 @@
+---
+'msw-auto-mock': minor
+---
+
+Added regex filter option (--regex) that allows using regex expressions for partial path matching in both include and exclude filters

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,9 +15,11 @@ cli
   .option('--static', 'By default it will generate dynamic mocks, use this flag if you want generate static mocks.')
   .option('-c, --codes <keywords>', 'Comma separated list of status codes to generate responses for')
   .option('--typescript', 'Generate TypeScript files instead of JavaScript files')
+  .option('--regex', `Use regex to match the request path.`)
   .example('msw-auto-mock ./githubapi.yaml -o mock.js')
   .example('msw-auto-mock ./githubapi.yaml -o mock.js -t /admin,/repo -m 30')
   .example('msw-auto-mock ./githubapi.yaml -o mock.js --typescript')
+  .example('msw-auto-mock ./githubapi.yaml -o mock.js --regex -t ^/\\\\w+$ -m 30')
   .action(async (spec, options) => {
     await generate(spec, options).catch(console.error);
   });

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -16,9 +16,10 @@ import { name as moduleName } from '../package.json';
 export function generateOperationCollection(apiDoc: OpenAPIV3.Document, options: CliOptions) {
   const apiGen = new ApiGenerator(apiDoc, {});
   const operationDefinitions = getOperationDefinitions(apiDoc);
+  const filters = parseFilterOptions(options);
 
   return operationDefinitions
-    .filter(op => operationFilter(op, options))
+    .filter(op => operationFilter(op, filters))
     .map(op => codeFilter(op, options))
     .map(definition => toOperation(definition, apiGen));
 }
@@ -109,15 +110,21 @@ function getOperationDefinitions(v3Doc: OpenAPIV3.Document): OperationDefinition
           }),
   );
 }
+function operationFilter(operation: OperationDefinition, filters: FilterDefinitions): boolean {
+  if (filters.regex) {
+    if (filters.excludes && filters.excludes.some(r => r.test(operation.path))) {
+      return false;
+    }
+    if (filters.includes && !filters.includes.some(r => r.test(operation.path))) {
+      return false;
+    }
+    return true;
+  }
 
-function operationFilter(operation: OperationDefinition, options: CliOptions): boolean {
-  const includes = options?.includes?.split(',') ?? null;
-  const excludes = options?.excludes?.split(',') ?? null;
-
-  if (includes && !includes.includes(operation.path)) {
+  if (filters.includes && !filters.includes.includes(operation.path)) {
     return false;
   }
-  if (excludes?.includes(operation.path)) {
+  if (filters.excludes?.includes(operation.path)) {
     return false;
   }
   return true;
@@ -239,4 +246,24 @@ function recursiveResolveSchema(schema: OpenAPIV3.ReferenceObject | OpenAPIV3.Sc
 
     return resolvedSchema;
   });
+}
+
+type FilterDefinitions =
+  | { regex: true; includes: RegExp[] | null; excludes: RegExp[] | null }
+  | { regex: false; includes: string[] | null; excludes: string[] | null };
+
+function parseFilterOptions(options: CliOptions): FilterDefinitions {
+  if (options.regex) {
+    return {
+      regex: true,
+      includes: options?.includes?.split(',')?.map(str => new RegExp(str)) ?? null,
+      excludes: options?.excludes?.split(',')?.map(str => new RegExp(str)) ?? null,
+    };
+  }
+
+  return {
+    regex: false,
+    includes: options?.includes?.split(',') ?? null,
+    excludes: options?.excludes?.split(',') ?? null,
+  };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export interface CliOptions {
   codes?: string;
   static?: boolean;
   typescript?: boolean;
+  regex?: boolean;
 }
 
 export type ConfigOptions = CliOptions & {

--- a/test/generate.spec.ts
+++ b/test/generate.spec.ts
@@ -84,3 +84,54 @@ describe('generate:generateOperationCollection', () => {
     expect(arrayEntity).toMatchObject({ type: 'object' });
   });
 });
+
+describe('generate:regex filtering', () => {
+  it('should include only paths matching regex includes pattern', async () => {
+    const apiDoc = await getV3Doc('./test/fixture/test.yaml');
+    const collection = generateOperationCollection(apiDoc, {
+      output: '',
+      regex: true,
+      includes: '^/test$'
+    });
+
+    expect(collection).toHaveLength(1);
+    expect(collection[0].path).toBe('/test');
+  });
+
+  it('should include paths matching any of multiple regex includes patterns', async () => {
+    const apiDoc = await getV3Doc('./test/fixture/test.yaml');
+    const collection = generateOperationCollection(apiDoc, {
+      output: '',
+      regex: true,
+      includes: '^/test$,^/test2$'
+    });
+
+    expect(collection).toHaveLength(2);
+    expect(collection.map(op => op.path)).toContain('/test');
+    expect(collection.map(op => op.path)).toContain('/test2');
+  });
+
+  it('should exclude paths matching regex excludes pattern', async () => {
+    const apiDoc = await getV3Doc('./test/fixture/test.yaml');
+    const collection = generateOperationCollection(apiDoc, {
+      output: '',
+      regex: true,
+      excludes: '^/test$'
+    });
+
+    expect(collection).toHaveLength(1);
+    expect(collection[0].path).toBe('/test2');
+  });
+
+  it('should work with complex regex patterns', async () => {
+    const apiDoc = await getV3Doc('./test/fixture/test.yaml');
+    const collection = generateOperationCollection(apiDoc, {
+      output: '',
+      regex: true,
+      includes: '/test\\d+'
+    });
+
+    expect(collection).toHaveLength(1);
+    expect(collection[0].path).toBe('/test2');
+  });
+});


### PR DESCRIPTION
Currently the `includes` option expect a full match on the path, this is not ideal for our usescase as our API has a lot of endpoint "namespaced" and our front-end only cares about one namespace and listing all the paths is a no no.

This `regex` option transforms the individual filters into regex expressions, the coma separation is persisted but now you can do a partial match on each path like `--regex -t ^\/namespace\/.*,auth`