### PR TITLE
fix: handle OpenAPI pattern as RegExp source

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -241,7 +241,13 @@ function transformStringBasedOnFormat(schema: OpenAPIV3.NonArraySchemaObject, ke
   }
 
   if (pattern && isValidRegExp(pattern)) {
-    return `faker.helpers.fromRegExp(${pattern})`;
+    // OpenAPI `pattern` is a bare regex source (e.g. ^[a-z]{2,}$), not a JS literal.
+    // Some users still pass JS regex literals as strings (e.g. '/^foo$/i'); support both.
+    if (pattern.startsWith('/')) {
+      return `faker.helpers.fromRegExp(${pattern})`;
+    }
+    // Use `new RegExp()` with a JSON-escaped string to avoid syntax errors.
+    return `faker.helpers.fromRegExp(new RegExp(${JSON.stringify(pattern)}))`;
   }
 
   return `faker.lorem.words()`;

--- a/test/transform.spec.ts
+++ b/test/transform.spec.ts
@@ -69,12 +69,22 @@ describe('transform:transformJSONSchemaToFakerCode', () => {
       expect(transformJSONSchemaToFakerCode(schema)).toBe(JSON.stringify(expected));
     });
 
-    it('Returns fromRegExp() if valid regexp pattern is provided', () => {
+    it('Returns fromRegExp() if a JS regexp literal is provided', () => {
       const schema: OpenAPIV3.SchemaObject = {
         type: 'string',
         pattern: '/^S+@S+.S+$/',
       };
       expect(transformJSONSchemaToFakerCode(schema)).toBe('faker.helpers.fromRegExp(/^S+@S+.S+$/)');
+    });
+
+    it('Returns fromRegExp(new RegExp()) if a bare regexp pattern is provided', () => {
+      const schema: OpenAPIV3.SchemaObject = {
+        type: 'string',
+        pattern: '^[a-zA-Z0-9-_]{2,50}$',
+      };
+      expect(transformJSONSchemaToFakerCode(schema)).toBe(
+        'faker.helpers.fromRegExp(new RegExp("^[a-zA-Z0-9-_]{2,50}$"))',
+      );
     });
 
     it('Falls back if invalid regexp pattern is provided', () => {


### PR DESCRIPTION
Fixes #99.

- Support bare OpenAPI pattern sources (e.g. ^[a-z]{2,}$) by emitting new RegExp("...")
- Keep supporting JS regex literal strings like '/^foo$/'
- Add tests covering both forms