### PR TITLE
fix: handle OpenAPI default responses

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -95,10 +95,12 @@ export function transformToHandlerCode(operationCollection: OperationCollection,
       return `http.${op.verb}(\`\${baseURL}${op.path}\`, async () => {
         const resultArray = [${op.response.map(response => {
           const identifier = getResIdentifierName(response);
+          const statusCode = parseInt(response?.code!);
+          const safeStatusCode = Number.isFinite(statusCode) ? statusCode : 500;
           const result =
-            parseInt(response?.code!) === 204
-              ? `[undefined, { status: ${parseInt(response?.code!)} }]`
-              : `[${identifier ? `${identifier}()` : 'undefined'}, { status: ${parseInt(response?.code!)} }]`;
+            safeStatusCode === 204
+              ? `[undefined, { status: ${safeStatusCode} }]`
+              : `[${identifier ? `${identifier}()` : 'undefined'}, { status: ${safeStatusCode} }]`;
 
           return result;
         })}]${options.typescript ? `as [any, { status: number }][]` : ''};

--- a/test/fixture/test.yaml
+++ b/test/fixture/test.yaml
@@ -84,6 +84,15 @@ paths:
   /test2:
     get:
       responses:
+        default:
+          description: Default
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
         '200':
           description: OK
           content:


### PR DESCRIPTION
Fixes #34.

When an operation defines a `default` response, the response key isn't a numeric status code. Previously this produced a `status: NaN`, which breaks `HttpResponse.json` at runtime.

This change falls back to status 500 when the response code cannot be parsed as a number.

Also adds a fixture covering a `default` response to prevent regressions.
