### PR TITLE
fix: resolve  in schema example values

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -205,6 +205,13 @@ function recursiveResolveSchema(schema: OpenAPIV3.ReferenceObject | OpenAPIV3.Sc
   return autoPopRefs(() => {
     const resolvedSchema = resolve(schema, apiGen) as OpenAPIV3.SchemaObject;
 
+    // OpenAPI examples may reference components via $ref; resolve them early so
+    // we don't emit `{ $ref: ... }` as literal example data.
+    const exampleRef = (resolvedSchema as any)?.example?.$ref;
+    if (typeof exampleRef === 'string') {
+      resolvedSchema.example = resolve({ $ref: exampleRef } as any, apiGen) as any;
+    }
+
     if (resolvedSchema.type === 'array') {
       resolvedSchema.items = resolve(resolvedSchema.items, apiGen);
       resolvedSchema.items = recursiveResolveSchema(resolvedSchema.items, apiGen);

--- a/test/fixture/test.yaml
+++ b/test/fixture/test.yaml
@@ -3,6 +3,12 @@ info:
   title: Test
   version: '1.0'
 components:
+  examples:
+    customerData:
+      value:
+        id: customer-id-test
+        createdAt: 1234567890
+        name: Customer name
   schemas:
     Creator:
       description: Creator
@@ -58,6 +64,17 @@ components:
           type: string
           enum:
             - success
+    Customer:
+      type: object
+      properties:
+        id:
+          type: string
+        createdAt:
+          type: integer
+        name:
+          type: string
+      example:
+        $ref: '#/components/examples/customerData/value'
 paths:
   /test:
     get:
@@ -104,3 +121,17 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/ObjectAllOfWrapper'
+  /test3:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Customer'

--- a/test/generate.spec.ts
+++ b/test/generate.spec.ts
@@ -83,4 +83,24 @@ describe('generate:generateOperationCollection', () => {
     ]);
     expect(arrayEntity).toMatchObject({ type: 'object' });
   });
+
+  it('should resolve $ref in example values', async () => {
+    const collection = await generateCollectionFromSpec('./test/fixture/test.yaml');
+    const customerExample = get(collection, [
+      2,
+      'response',
+      0,
+      'responses',
+      'application/json',
+      'properties',
+      'data',
+      'items',
+      'example',
+    ]);
+    expect(customerExample).toMatchObject({
+      id: 'customer-id-test',
+      createdAt: 1234567890,
+      name: 'Customer name',
+    });
+  });
 });


### PR DESCRIPTION
Fixes #37.

Some OpenAPI specs use `$ref` inside schema `example` values (often pointing at `#/components/examples/...`).
Previously we would treat that as literal JSON and emit `{ $ref: ... }`.

This change resolves `example.$ref` during schema resolution so generators see the expanded value.

Includes a fixture + test covering `example.$ref`.
