### PR TITLE
feat: optionally echo request JSON into write responses

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,6 +15,7 @@ cli
   .option('--static', 'By default it will generate dynamic mocks, use this flag if you want generate static mocks.')
   .option('-c, --codes <keywords>', 'Comma separated list of status codes to generate responses for')
   .option('--typescript', 'Generate TypeScript files instead of JavaScript files')
+  .option('--echo-request-body', 'Merge JSON request body into JSON response body for write requests (POST/PUT/PATCH)')
   .example('msw-auto-mock ./githubapi.yaml -o mock.js')
   .example('msw-auto-mock ./githubapi.yaml -o mock.js -t /admin,/repo -m 30')
   .example('msw-auto-mock ./githubapi.yaml -o mock.js --typescript')

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,12 @@ export interface CliOptions {
   codes?: string;
   static?: boolean;
   typescript?: boolean;
+
+  /**
+   * When enabled, JSON responses for write requests (POST/PUT/PATCH) will merge
+   * the request JSON body into the generated response body.
+   */
+  echoRequestBody?: boolean;
 }
 
 export type ConfigOptions = CliOptions & {

--- a/test/transform.spec.ts
+++ b/test/transform.spec.ts
@@ -56,6 +56,27 @@ describe('transform:transformToHandlerCode', () => {
     const out = transformToHandlerCode(ops as any, { output: '' } as any);
     expect(out.indexOf('/users/me')).toBeLessThan(out.indexOf('/users/:id'));
   });
+
+  it('can echo request body into JSON response when enabled', () => {
+    const ops = [
+      {
+        verb: 'post',
+        path: '/items',
+        response: [
+          {
+            code: '200',
+            id: 'Item',
+            responses: { 'application/json': { type: 'object' } as any },
+          },
+        ],
+      },
+    ];
+
+    const out = transformToHandlerCode(ops as any, { output: '', echoRequestBody: true } as any);
+    expect(out).toContain('async ({ request })');
+    expect(out).toContain('request.clone().json()');
+    expect(out).toContain('{ ...body, ...requestJson }');
+  });
 });
 
 describe('transform:transformJSONSchemaToFakerCode', () => {


### PR DESCRIPTION
Fixes #45.

Adds an opt-in flag to merge the incoming JSON request body into the generated JSON response for write requests (POST/PUT/PATCH).

- New CLI flag: `--echo-request-body`
- When enabled, the handler reads `request.clone().json()` and merges `{ ...generated, ...requestJson }` (object bodies only)
- Includes a unit test asserting the generated handler contains the echo logic

Rationale: helps integration tests where clients expect certain fields in the response to match what they sent.
