### PR TITLE
fix: await response generators in handlers (AI mode)

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -142,7 +142,7 @@ export function transformToHandlerCode(operationCollection: OperationCollection,
           const result =
             safeStatusCode === 204
               ? `[undefined, { status: ${safeStatusCode} }]`
-              : `[${identifier ? `${identifier}()` : 'undefined'}, { status: ${safeStatusCode} }]`;
+              : `[${identifier ? `await ${identifier}()` : 'undefined'}, { status: ${safeStatusCode} }]`;
 
           return result;
         })}]${options.typescript ? `as [any, { status: number }][]` : ''};

--- a/test/transform.spec.ts
+++ b/test/transform.spec.ts
@@ -77,6 +77,25 @@ describe('transform:transformToHandlerCode', () => {
     expect(out).toContain('request.clone().json()');
     expect(out).toContain('{ ...body, ...requestJson }');
   });
+
+  it('awaits response generators in the handler body (required for AI mode)', () => {
+    const ops = [
+      {
+        verb: 'get',
+        path: '/items',
+        response: [
+          {
+            code: '200',
+            id: 'Item',
+            responses: { 'application/json': { type: 'object' } as any },
+          },
+        ],
+      },
+    ];
+
+    const out = transformToHandlerCode(ops as any, { output: '' } as any);
+    expect(out).toContain('await getItem200Response()');
+  });
 });
 
 describe('transform:transformJSONSchemaToFakerCode', () => {


### PR DESCRIPTION
Fixes #96.

When AI mode is enabled, response generator functions are async. The generated MSW handler resolver must await them, otherwise it returns before the AI call completes and the response body is empty.

Changes:
- Generate `await getXxxResponse()` in handler result array
- Add unit test asserting the await is present

Tests:
- pnpm test
